### PR TITLE
Add ability to set custom env vars on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following environment variable options can be configured:
 |COMMIT|The commit SHA of the build. Optional.|`$GITHUB_SHA`|
 |BRANCH|The branch of the build. Optional.|`$GITHUB_REF`|
 |MESSAGE|The message for the build. Optional.||
+|BUILD_ENV_VARS|Additional environment variables to set on the build, as a json object, e.g. `"{"ENV_KEY": "value", "ENV_KEY_2": "value", "ENV_KEY_3": "value"}"`. Optional. ||
 
 ## Development
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,8 @@ MESSAGE="${MESSAGE:-}"
 NAME=$(jq ".pusher.name" "$GITHUB_EVENT_PATH")
 EMAIL=$(jq ".pusher.email" "$GITHUB_EVENT_PATH")
 
+BUILD_ENV_VARS="${BUILD_ENV_VARS:-}"
+    
 # Use jq’s --arg properly escapes string values for us
 JSON=$(
   jq -n \
@@ -41,6 +43,16 @@ JSON=$(
     }'
 )
 
+# Add additional env vars as a nested object
+FINAL_JSON=""
+if [[ "$BUILD_ENV_VARS" ]]; then
+    FINAL_JSON=$(
+      echo "$JSON" | jq --argjson env "$BUILD_ENV_VARS" '. + {env: $env}'
+    )
+else
+    FINAL_JSON=$JSON
+fi
+
 RESPONSE=$(
   curl \
     --fail \
@@ -48,7 +60,7 @@ RESPONSE=$(
     -X POST \
     -H "Authorization: Bearer ${BUILDKITE_API_ACCESS_TOKEN}" \
     "https://api.buildkite.com/v2/organizations/${ORG_SLUG}/pipelines/${PIPELINE_SLUG}/builds" \
-    -d "$JSON"
+    -d "$FINAL_JSON"
 )
 
 echo ""


### PR DESCRIPTION
Adding an option to the configuration for this action to pass a JSON object that will contain additional environment variables to be available to the created build (see https://buildkite.com/docs/apis/rest-api/builds#create-a-build, the env parameter)

The passed in JSON object will be set as the `env` property in the resulting payload that is passed to the `POST` request to the `/builds` Buildkite API