### PR TITLE
Fix author double quotes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,12 +19,12 @@ COMMIT="${COMMIT:-${GITHUB_SHA}}"
 BRANCH="${BRANCH:-${GITHUB_REF#"refs/heads/"}}"
 MESSAGE="${MESSAGE:-}"
 
-NAME=$(jq ".pusher.name" "$GITHUB_EVENT_PATH")
-EMAIL=$(jq ".pusher.email" "$GITHUB_EVENT_PATH")
+NAME=$(jq -r ".pusher.name" "$GITHUB_EVENT_PATH")
+EMAIL=$(jq -r ".pusher.email" "$GITHUB_EVENT_PATH")
 
 # Use jq’s --arg properly escapes string values for us
 JSON=$(
-  jq -n \
+  jq -c -n \
     --arg COMMIT  "$COMMIT" \
     --arg BRANCH  "$BRANCH" \
     --arg MESSAGE "$MESSAGE" \

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -3,7 +3,7 @@
 load "$BATS_PATH/load.bash"
 
 # Uncomment to enable stub debugging
-# export CURL_STUB_DEBUG=/dev/tty
+# if [[ -a /dev/tty ]]; then export CURL_STUB_DEBUG=/dev/tty; fi
 
 teardown() {
   unset BUILDKITE_API_ACCESS_TOKEN

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -3,7 +3,7 @@
 load "$BATS_PATH/load.bash"
 
 # Uncomment to enable stub debugging
-# if [[ -a /dev/tty ]]; then export CURL_STUB_DEBUG=/dev/tty; fi
+if [[ -a /dev/tty ]]; then export CURL_STUB_DEBUG=/dev/tty; fi
 
 teardown() {
   unset BUILDKITE_API_ACCESS_TOKEN
@@ -36,9 +36,9 @@ teardown() {
   export GITHUB_EVENT_PATH="tests/push.json"
   export GITHUB_ACTION="push"
 
-  # TODO: This stub shouldn't pass without verifying the JSON being posted is
-  # correct, but getting bats-mock to match the `-d {json}` part was impossible.
-  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"}}'
+
+  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
   run $PWD/entrypoint.sh
 

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -3,7 +3,7 @@
 load "$BATS_PATH/load.bash"
 
 # Uncomment to enable stub debugging
-if [[ -a /dev/tty ]]; then export CURL_STUB_DEBUG=/dev/tty; fi
+# if [[ -a /dev/tty ]]; then export CURL_STUB_DEBUG=/dev/tty; fi
 
 teardown() {
   unset BUILDKITE_API_ACCESS_TOKEN


### PR DESCRIPTION
The build author had unnecessary double quotes added to the fields. And we were also not actually testing the JSON payload in our bats tests. This fixes both.