### PR TITLE
Add DELETE_EVENT_REF for `delete` events

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,45 @@
 
 set -euo pipefail
 
+function is_delete_event() {
+  if [[ "$GITHUB_EVENT_NAME" == "delete" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+function get_delete_event_json() {
+  local DELETE_EVENT_JSON
+  local DELETE_EVENT_REF
+  
+  DELETE_EVENT_REF=$(jq --raw-output .ref "$GITHUB_EVENT_PATH")
+  DELETE_EVENT_JSON=$(
+    jq -c -n \
+      --arg DELETE_EVENT_REF "$DELETE_EVENT_REF" \
+      '{
+        DELETE_EVENT_REF: $DELETE_EVENT_REF,
+      }'
+  )
+  echo "$DELETE_EVENT_JSON"
+}
+
+function get_build_env_vars_json() {
+  if [[ "$1" ]] && [[ "$2" ]]; then
+    BUILD_ENV_VARS=$(
+      jq -c -s '.[0] * .[1]' \
+        <(echo "$1") \
+        <(echo "$2")
+    )
+  elif [[ "$1" ]]; then
+    BUILD_ENV_VARS=$1
+  elif [[ "$2" ]]; then
+    BUILD_ENV_VARS=$2
+  fi
+  
+  echo "$BUILD_ENV_VARS"
+}
+
 if [[ -z "${BUILDKITE_API_ACCESS_TOKEN:-}" ]]; then
   echo "You must set the BUILDKITE_API_ACCESS_TOKEN environment variable (e.g. BUILDKITE_API_ACCESS_TOKEN = \"xyz\")"
   exit 1
@@ -22,6 +61,23 @@ MESSAGE="${MESSAGE:-}"
 NAME=$(jq -r ".pusher.name" "$GITHUB_EVENT_PATH")
 EMAIL=$(jq -r ".pusher.email" "$GITHUB_EVENT_PATH")
 
+BUILD_ENV_VARS="${BUILD_ENV_VARS:-}"
+    
+DELETE_EVENT_JSON=""
+if is_delete_event; then
+    DELETE_EVENT_JSON="$(get_delete_event_json)"
+fi
+
+if [[ "$BUILD_ENV_VARS" ]]; then
+    if ! echo "$BUILD_ENV_VARS" | jq empty; then
+      echo ""
+      echo "Error: BUILD_ENV_VARS provided invalid JSON: $BUILD_ENV_VARS"
+      exit 1
+  fi
+fi
+
+BUILD_ENV_VARS_JSON="$(get_build_env_vars_json "$DELETE_EVENT_JSON" "$BUILD_ENV_VARS")"
+
 # Use jq’s --arg properly escapes string values for us
 JSON=$(
   jq -c -n \
@@ -41,13 +97,14 @@ JSON=$(
     }'
 )
 
-# Merge in the build environment variables, if they specified any
-if [[ "${BUILD_ENV_VARS:-}" ]]; then
-  if ! JSON=$(echo "$JSON" | jq -c --argjson BUILD_ENV_VARS "$BUILD_ENV_VARS" '. + {env: $BUILD_ENV_VARS}'); then
-    echo ""
-    echo "Error: BUILD_ENV_VARS provided invalid JSON: $BUILD_ENV_VARS"
-    exit 1
-  fi
+# Add additional env vars as a nested object
+FINAL_JSON=""
+if [[ "$BUILD_ENV_VARS_JSON" ]]; then
+    FINAL_JSON=$(
+      echo "$JSON" | jq -c --argjson env "$BUILD_ENV_VARS_JSON" '. + {env: $env}'
+    )
+else
+    FINAL_JSON=$JSON
 fi
 
 RESPONSE=$(
@@ -57,7 +114,7 @@ RESPONSE=$(
     -X POST \
     -H "Authorization: Bearer ${BUILDKITE_API_ACCESS_TOKEN}" \
     "https://api.buildkite.com/v2/organizations/${ORG_SLUG}/pipelines/${PIPELINE_SLUG}/builds" \
-    -d "$JSON"
+    -d "$FINAL_JSON"
 )
 
 echo ""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,9 +32,11 @@ function get_github_env_json() {
     jq -c -n \
       --arg GITHUB_REPOSITORY "$GITHUB_REPOSITORY" \
       --arg SOURCE_REPO_SHA "$GITHUB_SHA" \
+      --arg SOURCE_REPO_REF "${GITHUB_REF#"refs/heads/"}" \
       '{
         GITHUB_REPOSITORY: $GITHUB_REPOSITORY,
         SOURCE_REPO_SHA: $SOURCE_REPO_SHA,
+        SOURCE_REPO_REF: $SOURCE_REPO_REF,
       }'
   )
   echo "$GITHUB_EVENT_JSON"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ function get_github_env_json() {
 
 function get_build_env_vars_json() {
     BUILD_ENV_VARS=$(
-      jq -c -s '.[0] * .[1]' \
+      jq -c -s 'add' \
         <(echo "$1") \
         <(echo "$2") \
         <(echo "$3")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,8 +31,10 @@ function get_github_env_json() {
   GITHUB_EVENT_JSON=$(
     jq -c -n \
       --arg GITHUB_REPOSITORY "$GITHUB_REPOSITORY" \
+      --arg SOURCE_REPO_SHA "$GITHUB_SHA" \
       '{
         GITHUB_REPOSITORY: $GITHUB_REPOSITORY,
+        SOURCE_REPO_SHA: $SOURCE_REPO_SHA,
       }'
   )
   echo "$GITHUB_EVENT_JSON"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,19 +25,26 @@ function get_delete_event_json() {
   echo "$DELETE_EVENT_JSON"
 }
 
+function get_github_env_json() {
+  local GITHUB_EVENT_JSON
+  
+  GITHUB_EVENT_JSON=$(
+    jq -c -n \
+      --arg GITHUB_REPOSITORY "$GITHUB_REPOSITORY" \
+      '{
+        GITHUB_REPOSITORY: $GITHUB_REPOSITORY,
+      }'
+  )
+  echo "$GITHUB_EVENT_JSON"
+}
+
 function get_build_env_vars_json() {
-  if [[ "$1" ]] && [[ "$2" ]]; then
     BUILD_ENV_VARS=$(
       jq -c -s '.[0] * .[1]' \
         <(echo "$1") \
-        <(echo "$2")
+        <(echo "$2") \
+        <(echo "$3")
     )
-  elif [[ "$1" ]]; then
-    BUILD_ENV_VARS=$1
-  elif [[ "$2" ]]; then
-    BUILD_ENV_VARS=$2
-  fi
-  
   echo "$BUILD_ENV_VARS"
 }
 
@@ -76,7 +83,7 @@ if [[ "$BUILD_ENV_VARS" ]]; then
   fi
 fi
 
-BUILD_ENV_VARS_JSON="$(get_build_env_vars_json "$DELETE_EVENT_JSON" "$BUILD_ENV_VARS")"
+BUILD_ENV_VARS_JSON="$(get_build_env_vars_json "$DELETE_EVENT_JSON" "$BUILD_ENV_VARS" "$(get_github_env_json)")"
 
 # Use jq’s --arg properly escapes string values for us
 JSON=$(

--- a/tests/delete.json
+++ b/tests/delete.json
@@ -1,0 +1,7 @@
+{
+  "ref": "a-deleted-branch",
+  "pusher": {
+    "name": "The Pusher",
+    "email": "pusher@pusher.com"
+  }
+}

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -37,7 +37,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -64,7 +64,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"custom-commit","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo"}}'
+  EXPECTED_JSON='{"commit":"custom-commit","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -91,7 +91,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"custom-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"custom-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -118,7 +118,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"A custom message","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"A custom message","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -145,7 +145,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -189,7 +189,7 @@ teardown() {
   export GITHUB_EVENT_NAME="delete"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","GITHUB_REPOSITORY":"buildkite/test-repo"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -217,7 +217,7 @@ teardown() {
   export GITHUB_EVENT_NAME="delete"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -37,7 +37,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"a-branch"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -64,7 +64,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"custom-commit","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
+  EXPECTED_JSON='{"commit":"custom-commit","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"a-branch"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -91,7 +91,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"custom-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"custom-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"a-branch"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -118,7 +118,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"A custom message","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"A custom message","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"a-branch"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -145,7 +145,7 @@ teardown() {
   export GITHUB_ACTION="push"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"a-branch"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -189,7 +189,7 @@ teardown() {
   export GITHUB_EVENT_NAME="delete"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"master"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -217,7 +217,7 @@ teardown() {
   export GITHUB_EVENT_NAME="delete"
   export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"master"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -139,8 +139,9 @@ teardown() {
   export GITHUB_REF=refs/heads/a-branch
   export GITHUB_EVENT_PATH="tests/push.json"
   export GITHUB_ACTION="push"
+  export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"FOO":"bar"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -182,8 +183,9 @@ teardown() {
   export GITHUB_EVENT_PATH="tests/delete.json"
   export GITHUB_ACTION="delete"
   export GITHUB_EVENT_NAME="delete"
+  export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","GITHUB_REPOSITORY":"buildkite/test-repo"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -35,8 +35,9 @@ teardown() {
   export GITHUB_REF=refs/heads/a-branch
   export GITHUB_EVENT_PATH="tests/push.json"
   export GITHUB_ACTION="push"
+  export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -61,8 +62,9 @@ teardown() {
   export GITHUB_REF=refs/heads/a-branch
   export GITHUB_EVENT_PATH="tests/push.json"
   export GITHUB_ACTION="push"
+  export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"custom-commit","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"}}'
+  EXPECTED_JSON='{"commit":"custom-commit","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -87,8 +89,9 @@ teardown() {
   export GITHUB_REF=refs/heads/a-branch
   export GITHUB_EVENT_PATH="tests/push.json"
   export GITHUB_ACTION="push"
+  export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"custom-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"custom-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -113,8 +116,9 @@ teardown() {
   export GITHUB_REF=refs/heads/a-branch
   export GITHUB_EVENT_PATH="tests/push.json"
   export GITHUB_ACTION="push"
+  export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"A custom message","author":{"name":"The Pusher","email":"pusher@pusher.com"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"A custom message","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 
@@ -211,8 +215,9 @@ teardown() {
   export GITHUB_EVENT_PATH="tests/delete.json"
   export GITHUB_ACTION="delete"
   export GITHUB_EVENT_NAME="delete"
+  export GITHUB_REPOSITORY="buildkite/test-repo"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","FOO":"bar"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"master","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"DELETE_EVENT_REF":"a-deleted-branch","FOO":"bar","GITHUB_REPOSITORY":"buildkite/test-repo"}}'
 
   stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
 


### PR DESCRIPTION
When a delete event occurs, the default value for the `GITHUB_REF`
passed to the action is the default branch (https://developer.github.com/actions/managing-workflows/workflow-configuration-options/#events-supported-in-workflow-files). It might be useful to know what was deleted when triggering an action off of a delete event. This change will pass the `ref` of the deleted branch/tag as a custom `env` variable on the created build