### PR TITLE
curl: show error messages on stderr

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,6 @@ fi
 RESPONSE=$(
   curl \
     --fail \
-    --silent \
     -X POST \
     -H "Authorization: Bearer ${BUILDKITE_API_ACCESS_TOKEN}" \
     "https://api.buildkite.com/v2/organizations/${ORG_SLUG}/pipelines/${PIPELINE_SLUG}/builds" \


### PR DESCRIPTION
From the commit message:
```
The shell script has the -e option set.
Curl uses --fail and --silent. That means
that if curl fails in any way the error
details are swallowed.

Removing `--silent` will at least make an
error message appear on stderr, For example,
in my case:

curl: (22) The requested URL returned error: 404
```