### PR TITLE
Provide URL and JSON string as outputs to downstream actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ The following environment variable options can be configured:
 |MESSAGE|The message for the build. Optional.||
 |BUILD_ENV_VARS|Additional environment variables to set on the build, in JSON format. e.g. `{"FOO": "bar"}`. Optional. ||
 
+## Outputs
+
+The following outputs are provided by the action:
+
+|Output var|Description|
+|-|-|
+|url|The URL of the Buildkite build.|
+|json|The JSON response returned by the Buildkite API.|
+
 ## Development
 
 To run the test workflow, you use [act](https://github.com/nektos/act) which will run it just as it does on GitHub:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,16 +57,15 @@ RESPONSE=$(
     -X POST \
     -H "Authorization: Bearer ${BUILDKITE_API_ACCESS_TOKEN}" \
     "https://api.buildkite.com/v2/organizations/${ORG_SLUG}/pipelines/${PIPELINE_SLUG}/builds" \
-    -d "$JSON"
+    -d "$JSON" | tr -d '\n'
 )
 
 echo ""
 echo "Build created:"
-echo "$RESPONSE" | jq --raw-output ".web_url"
+URL=$(jq --raw-output ".web_url" <<< "$RESPONSE")
+echo $URL
 
-# Save output for downstream actions
-echo "${RESPONSE}" > "${HOME}/${GITHUB_ACTION}.json"
+# Provide JSON and Web URL as outputs for downstream actions
+echo "::set-output name=json::$RESPONSE"
+echo "::set-output name=url::$URL"
 
-echo ""
-echo "Saved build JSON to:"
-echo "${HOME}/${GITHUB_ACTION}.json"


### PR DESCRIPTION
This fixes #19 by providing the build URL and the entire JSON content as output strings. The JSON file that is currently created by the action exists only inside the action's container. There would have to be a volume mounted to persist that file outside the action.

Outputs can easily be set via special echo commands: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter

There is no extra configuration needed, only give the step a name (here `build`) to reference the JSON string or url in other steps or the [job outputs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-6):

```yaml
- name: Debug
  run: |
    echo "url: ${{ steps.build.outputs.url }}"
    echo "url from json object: ${{ fromJSON( steps.build.outputs.json ).web_url }}"
```