### PR TITLE
Provide URL and JSON as outputs to downstream actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A [GitHub Action](https://github.com/actions) for triggering a build on a [Build
 ## Features
 
 * Creates builds in Buildkite pipelines, setting commit, branch, message.
-* Saves the build JSON response to `${HOME}/${GITHUB_ACTION}.json` for downstream actions.
+* Provides the build JSON response and the build URL as outputs for downstream actions.
 
 ## Usage
 
@@ -45,6 +45,15 @@ The following environment variable options can be configured:
 |BRANCH|The branch of the build. Optional.|`$GITHUB_REF`|
 |MESSAGE|The message for the build. Optional.||
 |BUILD_ENV_VARS|Additional environment variables to set on the build, in JSON format. e.g. `{"FOO": "bar"}`. Optional. ||
+
+## Outputs
+
+The following outputs are provided by the action:
+
+|Output var|Description|
+|-|-|
+|url|The URL of the Buildkite build.|
+|json|The JSON response returned by the Buildkite API.|
 
 ## Development
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,16 +57,15 @@ RESPONSE=$(
     -X POST \
     -H "Authorization: Bearer ${BUILDKITE_API_ACCESS_TOKEN}" \
     "https://api.buildkite.com/v2/organizations/${ORG_SLUG}/pipelines/${PIPELINE_SLUG}/builds" \
-    -d "$JSON"
+    -d "$JSON" | tr -d '\n'
 )
 
 echo ""
 echo "Build created:"
-echo "$RESPONSE" | jq --raw-output ".web_url"
+URL=$(jq --raw-output ".web_url" <<< "$RESPONSE")
+echo $URL
 
-# Save output for downstream actions
-echo "${RESPONSE}" > "${HOME}/${GITHUB_ACTION}.json"
+# Provide JSON and Web URL as outputs for downstream actions
+echo "::set-output name=json::$RESPONSE"
+echo "::set-output name=url::$URL"
 
-echo ""
-echo "Saved build JSON to:"
-echo "${HOME}/${GITHUB_ACTION}.json"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,7 +68,7 @@ echo $URL
 # Provide JSON and Web URL as outputs for downstream actions
 # use environment variable $GITHUB_OUTPUT, or fall back to deprecated set-output command
 # https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
-if [[ -n "${GITHUB_OUTPUT}" ]]
+if [[ -n "${GITHUB_OUTPUT:-}" ]]
 then
   echo "json=$RESPONSE" >> ${GITHUB_OUTPUT}
   echo "url=$URL" >> ${GITHUB_OUTPUT}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,6 +66,14 @@ URL=$(jq --raw-output ".web_url" <<< "$RESPONSE")
 echo $URL
 
 # Provide JSON and Web URL as outputs for downstream actions
-echo "::set-output name=json::$RESPONSE"
-echo "::set-output name=url::$URL"
+# use environment variable $GITHUB_OUTPUT, or fall back to deprecated set-output command
+# https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+if [[ -n "${GITHUB_OUTPUT}" ]]
+then
+  echo "json=$RESPONSE" >> ${GITHUB_OUTPUT}
+  echo "url=$URL" >> ${GITHUB_OUTPUT}
+else
+  echo "::set-output name=json::$RESPONSE"
+  echo "::set-output name=url::$URL"
+fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,7 @@ RESPONSE=$(
 
 echo ""
 echo "Build created:"
-URL=$(jq --raw-output ".web_url" <<< "$RESPONSE")
+URL=$(echo "$RESPONSE" | jq --raw-output ".web_url")
 echo $URL
 
 # Provide JSON and Web URL as outputs for downstream actions

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -41,15 +41,16 @@ teardown() {
   export PIPELINE="my-org/my-pipeline"
 
   EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"}}'
+  RESPONSE_JSON='{"web_url": "https://buildkite.com/build-url"}'
 
-  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
+  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '$RESPONSE_JSON'"
 
   run "${PWD}"/entrypoint.sh
 
   assert_output --partial "Build created:"
   assert_output --partial "https://buildkite.com/build-url"
-  assert_output --partial "Saved build JSON to:"
-  assert_output --partial "${HOME}/push.json"
+  assert_output --partial "::set-output name=json::$RESPONSE_JSON"
+  assert_output --partial "::set-output name=url::https://buildkite.com/build-url"
 
   assert_success
 
@@ -62,15 +63,16 @@ teardown() {
   export COMMIT="custom-commit"
 
   EXPECTED_JSON='{"commit":"custom-commit","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"}}'
+  RESPONSE_JSON='{"web_url": "https://buildkite.com/build-url"}'
 
-  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
+  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '$RESPONSE_JSON'"
 
   run "${PWD}"/entrypoint.sh
 
   assert_output --partial "Build created:"
   assert_output --partial "https://buildkite.com/build-url"
-  assert_output --partial "Saved build JSON to:"
-  assert_output --partial "${HOME}/push.json"
+  assert_output --partial "::set-output name=json::$RESPONSE_JSON"
+  assert_output --partial "::set-output name=url::https://buildkite.com/build-url"
 
   assert_success
 
@@ -83,15 +85,16 @@ teardown() {
   export BRANCH="custom-branch"
 
   EXPECTED_JSON='{"commit":"a-sha","branch":"custom-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"}}'
+  RESPONSE_JSON='{"web_url": "https://buildkite.com/build-url"}'
 
-  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
+  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '$RESPONSE_JSON'"
 
   run "${PWD}"/entrypoint.sh
 
   assert_output --partial "Build created:"
   assert_output --partial "https://buildkite.com/build-url"
-  assert_output --partial "Saved build JSON to:"
-  assert_output --partial "${HOME}/push.json"
+  assert_output --partial "::set-output name=json::$RESPONSE_JSON"
+  assert_output --partial "::set-output name=url::https://buildkite.com/build-url"
 
   assert_success
 
@@ -104,15 +107,16 @@ teardown() {
   export MESSAGE="A custom message"
 
   EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"A custom message","author":{"name":"The Pusher","email":"pusher@pusher.com"}}'
+  RESPONSE_JSON='{"web_url": "https://buildkite.com/build-url"}'
 
-  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
+  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '$RESPONSE_JSON'"
 
   run "${PWD}"/entrypoint.sh
 
   assert_output --partial "Build created:"
   assert_output --partial "https://buildkite.com/build-url"
-  assert_output --partial "Saved build JSON to:"
-  assert_output --partial "${HOME}/push.json"
+  assert_output --partial "::set-output name=json::$RESPONSE_JSON"
+  assert_output --partial "::set-output name=url::https://buildkite.com/build-url"
 
   assert_success
 
@@ -125,15 +129,48 @@ teardown() {
   export BUILD_ENV_VARS="{\"FOO\": \"bar\"}"
 
   EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"FOO":"bar"}}'
+  RESPONSE_JSON='{"web_url": "https://buildkite.com/build-url"}'
 
-  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '{\"web_url\": \"https://buildkite.com/build-url\"}'"
+  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '$RESPONSE_JSON'"
 
   run "${PWD}"/entrypoint.sh
 
   assert_output --partial "Build created:"
   assert_output --partial "https://buildkite.com/build-url"
-  assert_output --partial "Saved build JSON to:"
-  assert_output --partial "${HOME}/push.json"
+  assert_output --partial "::set-output name=json::$RESPONSE_JSON"
+  assert_output --partial "::set-output name=url::https://buildkite.com/build-url"
+
+  assert_success
+
+  unstub curl
+}
+
+@test "Writes outputs to \$GITHUB_OUTPUT file if defined" {
+  TEST_TEMP_DIR="$(temp_make)"
+
+  export BUILDKITE_API_ACCESS_TOKEN="123"
+  export PIPELINE="my-org/my-pipeline"
+  export BUILD_ENV_VARS="{\"FOO\": \"bar\"}"
+  export GITHUB_OUTPUT=$TEST_TEMP_DIR/github_output_file
+
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"FOO":"bar"}}'
+  RESPONSE_JSON='{"web_url": "https://buildkite.com/build-url"}'
+
+  stub curl "--fail --silent -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '$RESPONSE_JSON'"
+
+  assert_file_not_exist $GITHUB_OUTPUT
+  assert_not_exist $GITHUB_OUTPUT
+
+  run "${PWD}"/entrypoint.sh
+
+  assert_output --partial "Build created:"
+  assert_output --partial "https://buildkite.com/build-url"
+  assert_file_exist $GITHUB_OUTPUT
+  assert_exist $GITHUB_OUTPUT
+
+  github_output=$(cat $GITHUB_OUTPUT)
+  expected_output=$(echo -e "json=$RESPONSE_JSON\nurl=https://buildkite.com/build-url\n")
+  assert_equal "$github_output" "$expected_output"
 
   assert_success
 


### PR DESCRIPTION
This fixes #19 by providing the build URL and the entire JSON content as output strings. The JSON file that is currently created by the action exists only inside the action's container. There would have to be a volume mounted to persist that file outside the action.

Outputs can easily be set via special echo commands: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter

There is no extra configuration needed, only give the step a name (here `build`) to reference the JSON string or url in other steps or the [job outputs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-6):

```yaml
- name: Debug
  run: |
    echo "url: ${{ steps.build.outputs.url }}"
    echo "url from json object: ${{ fromJSON( steps.build.outputs.json ).web_url }}"
```