### PR TITLE
Allow Setting `ignore_pipeline_branch_filters`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ The following environment variable options can be configured:
 
 |Env var|Description|Default|
 |-|-|-|
-|PIPELINE|The pipline to create a build on, in the format `<org-slug>/<pipeline-slug>`||
+|PIPELINE|The pipeline to create a build on, in the format `<org-slug>/<pipeline-slug>`||
 |COMMIT|The commit SHA of the build. Optional.|`$GITHUB_SHA`|
 |BRANCH|The branch of the build. Optional.|`$GITHUB_REF`|
 |MESSAGE|The message for the build. Optional.||
 |BUILD_ENV_VARS|Additional environment variables to set on the build, in JSON format. e.g. `{"FOO": "bar"}`. Optional. ||
+| IGNORE_PIPELINE_BRANCH_FILTER | Ignore pipeline branch filtering when creating a new build. true or false. Optional.||
 
 ## Development
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,15 @@ if [[ "${BUILD_ENV_VARS:-}" ]]; then
   fi
 fi
 
+# Merge in ignore_pipeline_branch_filters, if they specified a value
+if [[ "${IGNORE_PIPELINE_BRANCH_FILTER:-}" ]]; then
+  if ! JSON=$(echo "$JSON" | jq -c --argjson IGNORE_PIPELINE_BRANCH_FILTER "$IGNORE_PIPELINE_BRANCH_FILTER" '. + {ignore_pipeline_branch_filters: $IGNORE_PIPELINE_BRANCH_FILTER}'); then
+    echo ""
+    echo "Error: Could not set ignore_pipeline_branch_filters"
+    exit 1
+  fi
+fi
+
 RESPONSE=$(
   curl \
     --fail \


### PR DESCRIPTION
## Description

This PR allows setting the `ignore_pipeline_branch_filters` field in the request sent to Buildkite. Unless it is set to `true` the following error is returned when attempting to trigger a build (with certain pipeline configurations):
```json
{
  "message": "Branches have been disabled for this pipeline"
}
```

We recently switched all of our Buildkite pipelines to be managed by the [Buildkite Terraform provider](https://registry.terraform.io/providers/buildkite/buildkite/latest/docs). We set the following within the provider settings as we do not want the pipelines triggered by any events within GitHub:
```hcl
provider_settings {
  trigger_mode = "none"
}
```
This effectively turns off all triggers from GitHub. However, interestingly, it also prevents triggering a pipeline via the API and thus, this GitHub Action. The work-around appears to be to set `ignore_pipeline_branch_filters` to `true` within the body of the request to create a new build as mentioned in [this forum thread](https://forum.buildkite.community/t/request-build-error-branches-have-been-disabled-for-this-pipeline/1463).