### PR TITLE
Added support for `ignore_pipeline_branch_filters` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following environment variable options can be configured:
 |MESSAGE|The message for the build. Optional.||
 |BUILD_ENV_VARS|Additional environment variables to set on the build, in JSON format. e.g. `{"FOO": "bar"}`. Optional. ||
 |BUILD_META_DATA|Meta data to set on the build, in JSON format. e.g. `{"FOO": "bar"}`. Optional. ||
-
+|IGNORE_PIPELINE_BRANCH_FILTER | Ignore pipeline branch filtering when creating a new build. true or false. Optional. ||
 ## Outputs
 
 The following outputs are provided by the action:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,6 +66,15 @@ if [[ "${BUILD_ENV_VARS:-}" ]]; then
   fi
 fi
 
+# Merge in ignore_pipeline_branch_filters, if they specified a value
+if [[ "${IGNORE_PIPELINE_BRANCH_FILTER:-}" ]]; then
+  if ! JSON=$(echo "$JSON" | jq -c --argjson IGNORE_PIPELINE_BRANCH_FILTER "$IGNORE_PIPELINE_BRANCH_FILTER" '. + {ignore_pipeline_branch_filters: $IGNORE_PIPELINE_BRANCH_FILTER}'); then
+    echo ""
+    echo "Error: Could not set ignore_pipeline_branch_filters"
+    exit 1
+  fi
+fi
+
 CODE=0
 RESPONSE=$(
   curl \


### PR DESCRIPTION
Implementation of @willmark's [PR](https://github.com/buildkite/trigger-pipeline-action/pull/28) from the past.

Since opened, the structure in which tests had changed - and small amendments to the `entrypoint.sh` script which I've fed into.