### PR TITLE
Branding for 2.0 release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-trigger-pipeline/* @toolmantim
+* @jradtilbrook @mcncl @james2791 @lizrabuya

--- a/action.yml
+++ b/action.yml
@@ -31,3 +31,6 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'  
+branding:
+  icon: 'send'
+  color: 'green'


### PR DESCRIPTION
Github actions now require an icon for branding for release. 