### PR TITLE
add option to not send PULL_REQUEST_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ steps:
       build_env_vars: '{"TRIGGERED_FROM_GHA": "true"}'
       build_meta_data: '{"FOO": "bar"}'
       ignore_pipeline_branch_filter: true     
+      send_pull_request: true
 ```
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
    message:
      description: 'The message for the build'
      required: false
+   send_pull_request:
+     description: 'Whether to set PULL_REQUEST_ID, which sets BUILDKITE_PULL_REQUEST on the build. Does not work for cross-repo builds. Defaults to true'
+     required: false
    build_env_vars:
      description: 'Additional environment variables to set on the build, in JSON format'
      required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,7 +72,10 @@ MESSAGE="${INPUT_MESSAGE:-}"
 
 NAME=$(jq -r ".pusher.name" "$GITHUB_EVENT_PATH")
 EMAIL=$(jq -r ".pusher.email" "$GITHUB_EVENT_PATH")
-PULL_REQUEST_ID=$(jq -r '.pull_request.number // ""' "$GITHUB_EVENT_PATH")
+PULL_REQUEST_ID=""
+if [[ "${INPUT_SEND_PULL_REQUEST:-true}" == 'true' ]]; then
+  PULL_REQUEST_ID=$(jq -r '.pull_request.number // ""' "$GITHUB_EVENT_PATH")
+fi
 
 INPUT_BUILD_ENV_VARS="${INPUT_BUILD_ENV_VARS:-}"
 


### PR DESCRIPTION
https://github.com/buildkite/trigger-pipeline-action/commit/cdfaa26,
which came right after v1.4.0, always unconditionally sends `PULL_REQUEST_ID`

that causes Buildkite to set `BUILDKITE_PULL_REQUEST`,
which causes https://github.com/buildkite/agent/blob/080375a6fa6d4cf69bb76bb151c392e695d3c05b/clicommand/bootstrap.go#L159
to set `Executor.PullRequest`, which causes
https://github.com/buildkite/agent/blob/080375a6fa6d4cf69bb76bb151c392e695d3c05b/internal/job/checkout.go#L370
to checkout the code at that pull request (or fail if the pipeline's repo doesn't have a PR of the same number as the triggering PR)

at no point does the agent consider `BUILDKITE_PULL_REQUEST_REPO`
(perhaps as of 2022? https://buildkite.com/changelog/151-pull-request-repository-url-protocol)
this means that we can never have cross-repo triggers if `PULL_REQUEST_ID` is sent
(run an action whose code is in repo A triggered by a commit in repo B)