### PR TITLE
add pull_request_base_branch field

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
    send_pull_request:
      description: 'Whether to set PULL_REQUEST_ID, which sets BUILDKITE_PULL_REQUEST on the build. Does not work for cross-repo builds. Defaults to true'
      required: false
+   pull_request_base_branch:
+     description: 'For a pull request build, the base branch of the pull request.'
+     required: false
    build_env_vars:
      description: 'Additional environment variables to set on the build, in JSON format'
      required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,6 +73,7 @@ MESSAGE="${INPUT_MESSAGE:-}"
 NAME=$(jq -r ".pusher.name" "$GITHUB_EVENT_PATH")
 EMAIL=$(jq -r ".pusher.email" "$GITHUB_EVENT_PATH")
 PULL_REQUEST_ID=""
+PULL_REQUEST_BASE_BRANCH="${INPUT_PULL_REQUEST_BASE_BRANCH:-}"
 if [[ "${INPUT_SEND_PULL_REQUEST:-true}" == 'true' ]]; then
   PULL_REQUEST_ID=$(jq -r '.pull_request.number // ""' "$GITHUB_EVENT_PATH")
 fi
@@ -114,9 +115,12 @@ JSON=$(
     }'
 )
 
-# Link pull request if pull request id is specified
+# Link pull request and pull request base branch if pull request id is specified
 if [[ -n "$PULL_REQUEST_ID" ]]; then
   JSON=$(echo "$JSON" | jq -c --arg PULL_REQUEST_ID "$PULL_REQUEST_ID" '. + {pull_request_id: $PULL_REQUEST_ID}')
+  if [[ -n "$PULL_REQUEST_BASE_BRANCH" ]]; then
+    JSON=$(echo "$JSON" | jq -c --arg PULL_REQUEST_BASE_BRANCH "$PULL_REQUEST_BASE_BRANCH" '. + {pull_request_base_branch: $PULL_REQUEST_BASE_BRANCH}')
+  fi
 fi
 
 # Set build meta data, if specified

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -111,10 +111,11 @@ teardown() {
   
   export INPUT_BUILDKITE_API_ACCESS_TOKEN="123"
   export INPUT_PIPELINE="my-org/my-pipeline"
+  export INPUT_PULL_REQUEST_BASE_BRANCH="b-branch"
   export GITHUB_EVENT_PATH="tests/pullrequest.json"
   export GITHUB_EVENT_NAME="create"
 
-  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"pull_request_id":"1337","env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"a-branch"}}'
+  EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"pull_request_id":"1337","pull_request_base_branch":"b-branch","env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"a-branch"}}'
   RESPONSE_JSON='{"web_url": "https://buildkite.com/build-url"}'
 
   stub curl "--fail-with-body --silent --show-error -X POST -H \"Authorization: Bearer 123\" https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/builds -d '$EXPECTED_JSON' : echo '$RESPONSE_JSON'"


### PR DESCRIPTION
add the pull_request_base_branch field, which is an optional field for creating a buildkite build from a pull request (https://buildkite.com/docs/apis/rest-api/builds#create-a-build)

Test:
- docker run --rm -ti -v "$PWD":/plugin buildkite/plugin-tester:v4.0.0