### PR TITLE
chore: Update CODEOWNERS team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @buildkite/support-engineering
+* @buildkite/support


### PR DESCRIPTION
`support-engineering` team is deprecated so updating to current used team