### PR TITLE
tests/fix: Fix unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
           uses: actions/checkout@v3  
         - uses: addnab/docker-run-action@v3
           with:
-            image: buildkite/plugin-tester:v4.0.0
-            options: --rm -v ${{ github.workspace }}:/plugin 
+            image: buildkite/plugin-tester:v4.1.1
+            options: --rm -v ${{ github.workspace }}:/plugin
             run: bats tests/. 
    

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Create a [Buildkite API Access Token](https://buildkite.com/docs/apis/rest-api#a
 ## Inputs
 
 Refer to the [action.yml](./action.yml) for more detailed information on parameter use.
- 
+
 ### Example
 
-The following workflow creates a new Buildkite build to the target `pipeline` on every commit. 
-```
+The following workflow creates a new Buildkite build to the target `pipeline` on every commit.
+
+```yaml
 on: [push]
 
 steps:
@@ -47,7 +48,6 @@ The following outputs are provided by the action:
 |-|-|
 |url|The URL of the Buildkite build.|
 |json|The JSON response returned by the Buildkite API.|
-
 
 ## Development
 

--- a/tests/entrypoint.bats
+++ b/tests/entrypoint.bats
@@ -446,6 +446,7 @@ teardown() {
   export INPUT_WAIT="true"
   export INPUT_WAIT_INTERVAL="1"
   export GITHUB_EVENT_NAME="create"
+  export GITHUB_OUTPUT=$TEST_TEMP_DIR/github_output_file
 
   EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"a-branch"}}'
   CREATE_RESPONSE='{"web_url": "https://buildkite.com/build-url", "number": "123"}'
@@ -476,6 +477,7 @@ teardown() {
   export INPUT_WAIT="true"
   export INPUT_WAIT_INTERVAL="1"
   export GITHUB_EVENT_NAME="create"
+  export GITHUB_OUTPUT=$TEST_TEMP_DIR/github_output_file
 
   EXPECTED_JSON='{"commit":"a-sha","branch":"a-branch","message":"","author":{"name":"The Pusher","email":"pusher@pusher.com"},"env":{"GITHUB_REPOSITORY":"buildkite/test-repo","SOURCE_REPO_SHA":"a-sha","SOURCE_REPO_REF":"a-branch"}}'
   CREATE_RESPONSE='{"web_url": "https://buildkite.com/build-url", "number": "123"}'


### PR DESCRIPTION
`GITHUB_OUTPUT` was not set during BATS Tests but used in `entrypoint.sh`
Updated `plugin-tester` version and formatted README